### PR TITLE
Bump to SDK v2

### DIFF
--- a/projects/worker-animal-pictures/package-lock.json
+++ b/projects/worker-animal-pictures/package-lock.json
@@ -5,9 +5,9 @@
     "requires": true,
     "dependencies": {
         "@adobe/asset-compute-commons": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@adobe/asset-compute-commons/-/asset-compute-commons-1.0.1.tgz",
-            "integrity": "sha512-KVWiBDVr2FUW5GqGEEt8E9jXdg4tsNwsrBJ5Nr8hz8ern8kzOAggOAeOxnpu8idmfNSSN+xgr67B/M+AKrKFgw==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@adobe/asset-compute-commons/-/asset-compute-commons-1.1.0.tgz",
+            "integrity": "sha512-iEC0/82f7k+uBXJR44cCUBODUZ/2BcaB1iz13CgdBbWKlR06Hc+1eYqEiaHGqDRovWOWCMWkw5G4siBpms3ugw==",
             "requires": {
                 "@adobe/asset-compute-events-client": "^1.0.1",
                 "@adobe/openwhisk-newrelic": "^1.0.1",
@@ -43,25 +43,24 @@
             }
         },
         "@adobe/asset-compute-sdk": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@adobe/asset-compute-sdk/-/asset-compute-sdk-1.0.2.tgz",
-            "integrity": "sha512-yEPTsTsdhFn/QGBaVBKj4aFUu2UYNQXK5I45n3AbwGlEdQ+4FNd4Jmdpsr8JbKjlhu5YWp4MTmAzOkcKla7ezg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@adobe/asset-compute-sdk/-/asset-compute-sdk-2.0.0.tgz",
+            "integrity": "sha512-3hJPsPaVUMiWPUvHhv1ZUFnGWRWfvkJ+7nhhjJuHp29MvjUcfTtq64f2Ftwvi0wOXZ6qcUdMPBSK6JhrVS7nxg==",
             "requires": {
-                "@adobe/asset-compute-commons": "^1.0.1",
+                "@adobe/asset-compute-commons": "^1.1.0",
                 "@adobe/cgroup-metrics": "^3.0.0",
                 "@adobe/httptransfer": "^1.0.1",
                 "@adobe/metrics-sampler": "^1.0.0",
                 "@adobe/node-fetch-retry": "^1.0.1",
                 "ajv": "6.12.2",
                 "clone": "^2.1.2",
-                "data-uri-to-buffer": "^3.0.0",
+                "data-uri-to-buffer": "^3.0.1",
                 "deprecation": "^2.3.1",
-                "file-type": "^14.3.0",
-                "fs-extra": "^9.0.0",
+                "fs-extra": "^9.0.1",
                 "image-size": "^0.8.3",
                 "jsonwebtoken": "^8.5.1",
                 "mime-types": "^2.1.27",
-                "openwhisk": "^3.21.1",
+                "openwhisk": "^3.21.2",
                 "strip-ansi": "^6.0.0",
                 "valid-data-url": "^2.0.0",
                 "valid-url": "^1.0.9"
@@ -117,11 +116,6 @@
                 "node-fetch": "^2.6.0"
             }
         },
-        "@tokenizer/token": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.1.1.tgz",
-            "integrity": "sha512-XO6INPbZCxdprl+9qa/AAbFFOMzzwqYxpjPgLICrMD6C2FCw6qfJOPcBk6JqqPLSaZ/Qx87qn4rpPmPMwaAK6w=="
-        },
         "@tootallnate/once": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -135,11 +129,6 @@
                 "@types/node": "*"
             }
         },
-        "@types/debug": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
-            "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ=="
-        },
         "@types/form-data": {
             "version": "0.0.33",
             "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
@@ -149,9 +138,9 @@
             }
         },
         "@types/node": {
-            "version": "10.17.24",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.24.tgz",
-            "integrity": "sha512-5SCfvCxV74kzR3uWgTYiGxrd69TbT1I6+cMx1A5kEly/IVveJBimtAMlXiEyVFn5DvUFewQWxOOiJhlxeQwxgA=="
+            "version": "10.17.26",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.26.tgz",
+            "integrity": "sha512-myMwkO2Cr82kirHY8uknNRHEVtn0wV3DTQfkrjx17jmkstDRZ24gNUdl8AHXVyVclTYI/bNjgTPTAWvWLqXqkw=="
         },
         "@types/qs": {
             "version": "6.9.3",
@@ -159,9 +148,9 @@
             "integrity": "sha512-7s9EQWupR1fTc2pSMtXRQ9w9gLOcrJn+h7HOXw4evxyvVqMi4f+q7d2tnFe3ng3SNHjtK+0EzGMGFUQX4/AQRA=="
         },
         "agent-base": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
-            "integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
+            "integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
             "requires": {
                 "debug": "4"
             }
@@ -178,9 +167,9 @@
             },
             "dependencies": {
                 "fast-deep-equal": {
-                    "version": "3.1.1",
-                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-                    "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+                    "version": "3.1.3",
+                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+                    "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
                 },
                 "json-schema-traverse": {
                     "version": "0.4.1",
@@ -507,17 +496,6 @@
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
         },
-        "file-type": {
-            "version": "14.6.0",
-            "resolved": "https://registry.npmjs.org/file-type/-/file-type-14.6.0.tgz",
-            "integrity": "sha512-/Lg6yw7NtOVBe4wynSTDGyL32Jm+mqjYA7wZScjnEjYN1a68fhFhE75V2YEQPAfCoVtq6Mi02thUEYiOfTgLnQ==",
-            "requires": {
-                "readable-web-to-node-stream": "^2.0.0",
-                "strtok3": "^6.0.0",
-                "token-types": "^2.0.0",
-                "typedarray-to-buffer": "^3.1.5"
-            }
-        },
         "filter-obj": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-2.0.1.tgz",
@@ -674,11 +652,6 @@
             "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
             }
-        },
-        "ieee754": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
         },
         "ignore-walk": {
             "version": "3.0.3",
@@ -957,11 +930,6 @@
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
-        "peek-readable": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-3.1.0.tgz",
-            "integrity": "sha512-KGuODSTV6hcgdZvDrIDBUkN0utcAVj1LL7FfGbM0viKTtCHmtZcuEJ+lGqsp0fTFkGqesdtemV2yUSMeyy3ddA=="
-        },
         "performance-now": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -1023,11 +991,6 @@
                     "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
                 }
             }
-        },
-        "readable-web-to-node-stream": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-2.0.0.tgz",
-            "integrity": "sha512-+oZJurc4hXpaaqsN68GoZGQAQIA3qr09Or4fqEsargABnbe5Aau8hFn6ISVleT3cpY/0n/8drn7huyyEvTbghA=="
         },
         "request": {
             "version": "2.88.2",
@@ -1158,17 +1121,6 @@
                 "ansi-regex": "^5.0.0"
             }
         },
-        "strtok3": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.0.0.tgz",
-            "integrity": "sha512-ZXlmE22LZnIBvEU3n/kZGdh770fYFie65u5+2hLK9s74DoFtpkQIdBZVeYEzlolpGa+52G5IkzjUWn+iXynOEQ==",
-            "requires": {
-                "@tokenizer/token": "^0.1.1",
-                "@types/debug": "^4.1.5",
-                "debug": "^4.1.1",
-                "peek-readable": "^3.1.0"
-            }
-        },
         "stubs": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
@@ -1237,15 +1189,6 @@
                 "rimraf": "^3.0.0"
             }
         },
-        "token-types": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/token-types/-/token-types-2.0.0.tgz",
-            "integrity": "sha512-WWvu8sGK8/ZmGusekZJJ5NM6rRVTTDO7/bahz4NGiSDb/XsmdYBn6a1N/bymUHuWYTWeuLUg98wUzvE4jPdCZw==",
-            "requires": {
-                "@tokenizer/token": "^0.1.0",
-                "ieee754": "^1.1.13"
-            }
-        },
         "topojson-client": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
@@ -1280,14 +1223,6 @@
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
             "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-        },
-        "typedarray-to-buffer": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-            "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-            "requires": {
-                "is-typedarray": "^1.0.0"
-            }
         },
         "universalify": {
             "version": "1.0.0",

--- a/projects/worker-animal-pictures/package.json
+++ b/projects/worker-animal-pictures/package.json
@@ -6,7 +6,7 @@
     "description": "Asset Compute example custom worker - Animal Pictures",
     "repository": "adobe/example-worker-animal-pictures",
     "dependencies": {
-        "@adobe/asset-compute-sdk": "^1.0.2",
+        "@adobe/asset-compute-sdk": "^2.0.0",
         "@adobe/httptransfer": "^1.0.1"
     },
     "scripts": {

--- a/projects/worker-animal-pictures/worker-animal-pictures.js
+++ b/projects/worker-animal-pictures/worker-animal-pictures.js
@@ -12,8 +12,7 @@
 
 'use strict';
 
-const { worker } = require('@adobe/asset-compute-sdk');
-const { RenditionFormatUnsupportedError } = require('@adobe/asset-compute-sdk/errors');
+const { worker, RenditionFormatUnsupportedError } = require('@adobe/asset-compute-sdk');
 const { downloadFile } = require('@adobe/httptransfer');
 const urls = require('./lib/urls');
 

--- a/projects/worker-basic/package-lock.json
+++ b/projects/worker-basic/package-lock.json
@@ -5,9 +5,9 @@
     "requires": true,
     "dependencies": {
         "@adobe/asset-compute-commons": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@adobe/asset-compute-commons/-/asset-compute-commons-1.0.1.tgz",
-            "integrity": "sha512-KVWiBDVr2FUW5GqGEEt8E9jXdg4tsNwsrBJ5Nr8hz8ern8kzOAggOAeOxnpu8idmfNSSN+xgr67B/M+AKrKFgw==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@adobe/asset-compute-commons/-/asset-compute-commons-1.1.0.tgz",
+            "integrity": "sha512-iEC0/82f7k+uBXJR44cCUBODUZ/2BcaB1iz13CgdBbWKlR06Hc+1eYqEiaHGqDRovWOWCMWkw5G4siBpms3ugw==",
             "requires": {
                 "@adobe/asset-compute-events-client": "^1.0.1",
                 "@adobe/openwhisk-newrelic": "^1.0.1",
@@ -43,25 +43,24 @@
             }
         },
         "@adobe/asset-compute-sdk": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@adobe/asset-compute-sdk/-/asset-compute-sdk-1.0.2.tgz",
-            "integrity": "sha512-yEPTsTsdhFn/QGBaVBKj4aFUu2UYNQXK5I45n3AbwGlEdQ+4FNd4Jmdpsr8JbKjlhu5YWp4MTmAzOkcKla7ezg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@adobe/asset-compute-sdk/-/asset-compute-sdk-2.0.0.tgz",
+            "integrity": "sha512-3hJPsPaVUMiWPUvHhv1ZUFnGWRWfvkJ+7nhhjJuHp29MvjUcfTtq64f2Ftwvi0wOXZ6qcUdMPBSK6JhrVS7nxg==",
             "requires": {
-                "@adobe/asset-compute-commons": "^1.0.1",
+                "@adobe/asset-compute-commons": "^1.1.0",
                 "@adobe/cgroup-metrics": "^3.0.0",
                 "@adobe/httptransfer": "^1.0.1",
                 "@adobe/metrics-sampler": "^1.0.0",
                 "@adobe/node-fetch-retry": "^1.0.1",
                 "ajv": "6.12.2",
                 "clone": "^2.1.2",
-                "data-uri-to-buffer": "^3.0.0",
+                "data-uri-to-buffer": "^3.0.1",
                 "deprecation": "^2.3.1",
-                "file-type": "^14.3.0",
-                "fs-extra": "^9.0.0",
+                "fs-extra": "^9.0.1",
                 "image-size": "^0.8.3",
                 "jsonwebtoken": "^8.5.1",
                 "mime-types": "^2.1.27",
-                "openwhisk": "^3.21.1",
+                "openwhisk": "^3.21.2",
                 "strip-ansi": "^6.0.0",
                 "valid-data-url": "^2.0.0",
                 "valid-url": "^1.0.9"
@@ -117,11 +116,6 @@
                 "node-fetch": "^2.6.0"
             }
         },
-        "@tokenizer/token": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.1.1.tgz",
-            "integrity": "sha512-XO6INPbZCxdprl+9qa/AAbFFOMzzwqYxpjPgLICrMD6C2FCw6qfJOPcBk6JqqPLSaZ/Qx87qn4rpPmPMwaAK6w=="
-        },
         "@tootallnate/once": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -135,11 +129,6 @@
                 "@types/node": "*"
             }
         },
-        "@types/debug": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
-            "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ=="
-        },
         "@types/form-data": {
             "version": "0.0.33",
             "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
@@ -149,9 +138,9 @@
             }
         },
         "@types/node": {
-            "version": "10.17.24",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.24.tgz",
-            "integrity": "sha512-5SCfvCxV74kzR3uWgTYiGxrd69TbT1I6+cMx1A5kEly/IVveJBimtAMlXiEyVFn5DvUFewQWxOOiJhlxeQwxgA=="
+            "version": "10.17.26",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.26.tgz",
+            "integrity": "sha512-myMwkO2Cr82kirHY8uknNRHEVtn0wV3DTQfkrjx17jmkstDRZ24gNUdl8AHXVyVclTYI/bNjgTPTAWvWLqXqkw=="
         },
         "@types/qs": {
             "version": "6.9.3",
@@ -159,9 +148,9 @@
             "integrity": "sha512-7s9EQWupR1fTc2pSMtXRQ9w9gLOcrJn+h7HOXw4evxyvVqMi4f+q7d2tnFe3ng3SNHjtK+0EzGMGFUQX4/AQRA=="
         },
         "agent-base": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
-            "integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
+            "integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
             "requires": {
                 "debug": "4"
             }
@@ -178,9 +167,9 @@
             },
             "dependencies": {
                 "fast-deep-equal": {
-                    "version": "3.1.1",
-                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-                    "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+                    "version": "3.1.3",
+                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+                    "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
                 },
                 "json-schema-traverse": {
                     "version": "0.4.1",
@@ -507,17 +496,6 @@
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
         },
-        "file-type": {
-            "version": "14.6.0",
-            "resolved": "https://registry.npmjs.org/file-type/-/file-type-14.6.0.tgz",
-            "integrity": "sha512-/Lg6yw7NtOVBe4wynSTDGyL32Jm+mqjYA7wZScjnEjYN1a68fhFhE75V2YEQPAfCoVtq6Mi02thUEYiOfTgLnQ==",
-            "requires": {
-                "readable-web-to-node-stream": "^2.0.0",
-                "strtok3": "^6.0.0",
-                "token-types": "^2.0.0",
-                "typedarray-to-buffer": "^3.1.5"
-            }
-        },
         "filter-obj": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-2.0.1.tgz",
@@ -674,11 +652,6 @@
             "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
             }
-        },
-        "ieee754": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
         },
         "ignore-walk": {
             "version": "3.0.3",
@@ -957,11 +930,6 @@
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
-        "peek-readable": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-3.1.0.tgz",
-            "integrity": "sha512-KGuODSTV6hcgdZvDrIDBUkN0utcAVj1LL7FfGbM0viKTtCHmtZcuEJ+lGqsp0fTFkGqesdtemV2yUSMeyy3ddA=="
-        },
         "performance-now": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -1023,11 +991,6 @@
                     "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
                 }
             }
-        },
-        "readable-web-to-node-stream": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-2.0.0.tgz",
-            "integrity": "sha512-+oZJurc4hXpaaqsN68GoZGQAQIA3qr09Or4fqEsargABnbe5Aau8hFn6ISVleT3cpY/0n/8drn7huyyEvTbghA=="
         },
         "request": {
             "version": "2.88.2",
@@ -1158,17 +1121,6 @@
                 "ansi-regex": "^5.0.0"
             }
         },
-        "strtok3": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.0.0.tgz",
-            "integrity": "sha512-ZXlmE22LZnIBvEU3n/kZGdh770fYFie65u5+2hLK9s74DoFtpkQIdBZVeYEzlolpGa+52G5IkzjUWn+iXynOEQ==",
-            "requires": {
-                "@tokenizer/token": "^0.1.1",
-                "@types/debug": "^4.1.5",
-                "debug": "^4.1.1",
-                "peek-readable": "^3.1.0"
-            }
-        },
         "stubs": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
@@ -1237,15 +1189,6 @@
                 "rimraf": "^3.0.0"
             }
         },
-        "token-types": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/token-types/-/token-types-2.0.0.tgz",
-            "integrity": "sha512-WWvu8sGK8/ZmGusekZJJ5NM6rRVTTDO7/bahz4NGiSDb/XsmdYBn6a1N/bymUHuWYTWeuLUg98wUzvE4jPdCZw==",
-            "requires": {
-                "@tokenizer/token": "^0.1.0",
-                "ieee754": "^1.1.13"
-            }
-        },
         "topojson-client": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
@@ -1280,14 +1223,6 @@
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
             "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-        },
-        "typedarray-to-buffer": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-            "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-            "requires": {
-                "is-typedarray": "^1.0.0"
-            }
         },
         "universalify": {
             "version": "1.0.0",

--- a/projects/worker-basic/package.json
+++ b/projects/worker-basic/package.json
@@ -6,7 +6,7 @@
     "description": "Asset Compute example custom worker",
     "repository": "adobe/example-custom-worker",
     "dependencies": {
-        "@adobe/asset-compute-sdk": "^1.0.2"
+        "@adobe/asset-compute-sdk": "^2.0.0"
     },
     "scripts": {
         "test": "aio asset-compute test-worker"


### PR DESCRIPTION
Use Adobe Asset Compute SDK v2 in the examples. 
Related to https://github.com/adobe/generator-aio-app/pull/79, to have examples for the new generator.