### PR TITLE
no limit on axios post maxBodyLength

### DIFF
--- a/projects/worker-ccai-colorextract/worker-ccai-colorextract.js
+++ b/projects/worker-ccai-colorextract/worker-ccai-colorextract.js
@@ -153,18 +153,18 @@ exports.main = worker(async (source, rendition, params) => {
     }
 
     // Execute request
-    const response = await axios.post(
-        endpoint,
-        formData,
-        {
-            headers: Object.assign({
-                'Authorization': 'Bearer ' + accessToken,
-                'cache-control': 'no-cache,no-cache',
-                'Content-Type': 'multipart/form-data',
-                'x-api-key': clientId,
-            }, formData.getHeaders())
-        }
-    );
+    const response = await axios({
+        method: 'post',
+        url: endpoint,
+        data: formData,
+        maxBodyLength: Infinity,
+        headers: Object.assign({
+            'Authorization': `Bearer ${accessToken}`,
+            'cache-control': 'no-cache,no-cache',
+            'Content-Type': 'multipart/form-data',
+            'x-api-key': clientId,
+        }, formData.getHeaders())
+    });
 
     // Parse, sort, serialize to XMP
     const colors = parseColors(response.data);

--- a/projects/worker-ccai-pdfextract/worker-ccai-pdfextract.js
+++ b/projects/worker-ccai-pdfextract/worker-ccai-pdfextract.js
@@ -151,7 +151,6 @@ exports.main = worker(async (source, rendition, params) => {
             method: 'post',
             url: endpoint,
             data: formData,
-            maxContentLength: Infinity,
             maxBodyLength: Infinity,
             headers: Object.assign({
                 'Authorization': `Bearer ${accessToken}`,

--- a/projects/worker-ccai-pdfextract/worker-ccai-pdfextract.js
+++ b/projects/worker-ccai-pdfextract/worker-ccai-pdfextract.js
@@ -147,18 +147,19 @@ exports.main = worker(async (source, rendition, params) => {
     }
 
     // Execute request
-    const response = await axios.post(
-        endpoint,
-        formData,
-        {
+    const response = await axios({
+            method: 'post',
+            url: endpoint,
+            data: formData,
+            maxContentLength: Infinity,
+            maxBodyLength: Infinity,
             headers: Object.assign({
                 'Authorization': `Bearer ${accessToken}`,
                 'cache-control': 'no-cache,no-cache',
                 'Content-Type': 'multipart/form-data',
                 'x-api-key': clientId,
             }, formData.getHeaders())
-        }
-    );
+    });
     const entities = parseEntities(response.data);
 
     // Parse, sort, serialize to XMP


### PR DESCRIPTION
## Bug reported
file failing: `Rituals_DM_Quality_BestPractice_V1.pdf` (you can find it inside s3 `nui-meahana` bucket under `source/Rituals_DM_Quality_BestPractice_V1.pdf`
error: 
```js
Error [ERR_FR_MAX_BODY_LENGTH_EXCEEDED]: Request body larger than maxBodyLength limit
    at RedirectableRequest.module.exports.RedirectableRequest.write (/nodejsAction/JtvC1puJ/index.js:55180:24)
    at FormData.ondata (internal/streams/legacy.js:19:31)
    at FormData.emit (events.js:310:20)
```

## Solution
[axios](https://www.npmjs.com/package/axios#request-config) has a request option to set the `maxBodyLength` size for the request. I just changed it to `Infinity`

## Testing

I tested manually with the file in the devtool and it worked:
<img width="1607" alt="Screen Shot 2020-09-30 at 2 23 18 PM" src="https://user-images.githubusercontent.com/20048485/94742024-e5455200-0329-11eb-9507-dcdf7c71167d.png">
