### PR TITLE
Travis CI: add sizewatcher

### DIFF
--- a/.sizewatcher.yml
+++ b/.sizewatcher.yml
@@ -1,0 +1,17 @@
+comparators:
+  node_modules:
+    dir:
+      - "projects/worker-animal-pictures"
+      - "projects/worker-azure-ai"
+      - "projects/worker-basic"
+      - "projects/worker-ccai-colorextract"
+      - "projects/worker-ccai-pdfextract"
+      - "projects/worker-metadata"
+  npm_package:
+    dir:
+      - "projects/worker-animal-pictures"
+      - "projects/worker-azure-ai"
+      - "projects/worker-basic"
+      - "projects/worker-ccai-colorextract"
+      - "projects/worker-ccai-pdfextract"
+      - "projects/worker-metadata"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,8 @@ install:
 
 script:
   - cd $TEST_DIR && npm install && npm test
+
 after_script:
+  - cd $TRAVIS_BUILD_DIR
+  - pwd
   - npx @adobe/sizewatcher@latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,5 @@ install:
 
 script:
   - cd $TEST_DIR && npm install && npm test
+after_script:
+  - npx @adobe/sizewatcher

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ install:
 script:
   - cd $TEST_DIR && npm install && npm test
 after_script:
-  - npx @adobe/sizewatcher
+  - npx @adobe/sizewatcher@latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,4 @@ script:
 
 after_script:
   - cd $TRAVIS_BUILD_DIR
-  - pwd
-  - npx @adobe/sizewatcher@latest
+  - npx @adobe/sizewatcher


### PR DESCRIPTION
This updates the travis CI jobs to run [@adobe/sizewatcher](https://github.com/adobe/sizewatcher).

This tool warns if pull requests introduce large size increases (e.g. npm modules dependencies, package size etc.).