### PR TITLE
Add temporary workaround for AEM presigned photoshopAction urls

### DIFF
--- a/projects/worker-cc-photoshop/actions/worker-cc-photoshop/index.js
+++ b/projects/worker-cc-photoshop/actions/worker-cc-photoshop/index.js
@@ -70,7 +70,7 @@ async function setupPhotoshopActionsOptions(client, instructions, files) {
         }
         if (!ext) {
             const tempActionFilename = `${uuidv4()}_temp.atn`;
-            const aioLibActionFilename = `${uuidv4()}/photoshopaction.atn`;;
+            const aioLibActionFilename = `${uuidv4()}/photoshopaction.atn`;
             await downloadFile(photoshopAction, tempActionFilename);
             await files.copy(tempActionFilename, aioLibActionFilename, { localSrc: true });
             photoshopAction = aioLibActionFilename;

--- a/projects/worker-cc-photoshop/actions/worker-cc-photoshop/index.js
+++ b/projects/worker-cc-photoshop/actions/worker-cc-photoshop/index.js
@@ -64,18 +64,18 @@ async function setupPhotoshopActionsOptions(client, instructions, files) {
     // recognize it
     let photoshopAction = instructions.photoshopAction;
     let ext;
-        try {
-            ext = path.extname(photoshopAction).substring(1).toLowerCase();
-        } catch (err) {
-        }
-        if (!ext) {
-            const tempActionFilename = `${uuidv4()}_temp.atn`;
-            const aioLibActionFilename = `${uuidv4()}/photoshopaction.atn`;
-            await downloadFile(photoshopAction, tempActionFilename);
-            await files.copy(tempActionFilename, aioLibActionFilename, { localSrc: true });
-            photoshopAction = aioLibActionFilename;
-            
-        }
+    try {
+        ext = path.extname(photoshopAction).substring(1).toLowerCase();
+    } catch (err) {
+    }
+    if (!ext) {
+        const tempActionFilename = `${uuidv4()}_temp.atn`;
+        const aioLibActionFilename = `${uuidv4()}/photoshopaction.atn`;
+        await downloadFile(photoshopAction, tempActionFilename);
+        await files.copy(tempActionFilename, aioLibActionFilename, { localSrc: true });
+        photoshopAction = aioLibActionFilename;
+        
+    }
     const options = {
         actions: [{
             href: photoshopAction

--- a/projects/worker-cc-photoshop/actions/worker-cc-photoshop/index.js
+++ b/projects/worker-cc-photoshop/actions/worker-cc-photoshop/index.js
@@ -57,7 +57,7 @@ async function setupPhotoshopActionsOptions(client, instructions, files) {
     if (!instructions || !instructions.photoshopAction) {
         throw Error("Photoshop Action url not provided");
     }
-    
+
     // workaround for action files from AEM
     // we must download the action file and add the `.atn`
     // extension to the file so Photoshop Service can
@@ -76,7 +76,11 @@ async function setupPhotoshopActionsOptions(client, instructions, files) {
             photoshopAction = aioLibActionFilename;
             
         }
-    const options = await client.fileResolver.resolveInputsPhotoshopActionsOptions({ actions: photoshopAction });
+    const options = {
+        actions: [{
+            href: photoshopAction
+        }]
+    }
     if (options && Array.isArray(options.actions) && instructions.photoshopActionName) {
         options.actions[0].actionName = instructions.photoshopActionName;
     }

--- a/projects/worker-cc-photoshop/package-lock.json
+++ b/projects/worker-cc-photoshop/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "worker-cc-photoshop",
-  "version": "0.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/projects/worker-cc-photoshop/package.json
+++ b/projects/worker-cc-photoshop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worker-cc-photoshop",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "description": "Asset Compute custom worker leveraging Photoshop Actions in the Photoshop API",
   "dependencies": {

--- a/projects/worker-cc-photoshop/package.json
+++ b/projects/worker-cc-photoshop/package.json
@@ -1,12 +1,13 @@
 {
   "name": "worker-cc-photoshop",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "private": true,
   "description": "Asset Compute custom worker leveraging Photoshop Actions in the Photoshop API",
   "dependencies": {
     "@adobe/aio-lib-files": "^2.0.0",
     "@adobe/aio-lib-photoshop-api": "0.0.4-beta.2",
     "@adobe/asset-compute-sdk": "^2.2.1",
+    "@adobe/httptransfer": "^2.0.1",
     "uuid": "^8.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
see slack thread for full discussion: https://cq-dev.slack.com/archives/GJ49PQJ0Z/p1608072574109700
See ticket in AEM: https://jira.corp.adobe.com/browse/CQ-4312131

## Description

When choosing a `.atn` file in AEM for the `photoshopAction` custom parameter in the processing profile, the presigned url sent from AEM does not contain an extension so the photoshop service does not recognize this as a `.atn` file and consequently does not apply the photoshop action. 

As discussed in slack, the workaround is to download the file locally and upload the file to [aio-lib-files](https://github.com/adobe/aio-lib-files/blob/master/doc/api.md#filescopysrcpath-destpath-options--promiseobjectstring-string) with the `.atn` extension added to the file. 

example processing profile:
<img width="684" alt="Screen Shot 2020-12-15 at 6 03 58 PM" src="https://user-images.githubusercontent.com/20048485/102295775-efc2c100-3f00-11eb-85f2-3f4c34372ebb.png">

## Testing
Tested e2e in meahana & aem using sample url AEM sent previously without extension:
<img width="1603" alt="Screen Shot 2020-12-15 at 5 47 57 PM" src="https://user-images.githubusercontent.com/20048485/102295820-049f5480-3f01-11eb-9e8d-c83db5eb20d0.png">

