### PR TITLE
add instructions to add a new firefly project

### DIFF
--- a/projects/worker-cc-photoshop/README.md
+++ b/projects/worker-cc-photoshop/README.md
@@ -21,6 +21,7 @@ These can be enabled in a AEM Cloud environment by following these steps:
 - Switch to the Projects page
 - Find the AEM Cloud environment, once found click on the AEM Cloud environment
   - You should see the overview page with the Products & Services: I/O Management API, Asset Compute, I/O Events, Experience Platform Launch API, and Asset Compute Journal
+  - If your AEM Cloud Environment does not have runtime enabled, [create a new project using the Firefly Template](https://experienceleague.adobe.com/docs/asset-compute/using/extend/setup-environment.html?lang=en#create-firefly-project) in the same org. Add the necessary services listed above to the workspace you would like to work in:  I/O Management API, Asset Compute, I/O Events, Experience Platform Launch API, and Asset Compute Journal
 - Add _Photoshop API - Creative Cloud Automation Services_:
   - Click on _Add to Project_
   - Select _API_

--- a/projects/worker-cc-photoshop/README.md
+++ b/projects/worker-cc-photoshop/README.md
@@ -17,7 +17,7 @@ In order to utilize these APIs, the APIs are added to the existing Asset Compute
 These can be enabled in a AEM Cloud environment by following these steps:
 
 - Log in to <https://console.adobe.io/>
-- Switch to the correct organization in the top right corner. This must be the org where you AEM Cloud environment exists.
+- Switch to the correct organization in the top right corner. This must be the org where your AEM Cloud environment exists.
 - Switch to the Projects page
 - [Create a new project using the Firefly Template](https://experienceleague.adobe.com/docs/asset-compute/using/extend/setup-environment.html?lang=en#create-firefly-project). Move into the workspace you would like to work in.
 - Add the necessary services for Asset Compute Development:  I/O Management API, Asset Compute, I/O Events

--- a/projects/worker-cc-photoshop/README.md
+++ b/projects/worker-cc-photoshop/README.md
@@ -17,22 +17,22 @@ In order to utilize these APIs, the APIs are added to the existing Asset Compute
 These can be enabled in a AEM Cloud environment by following these steps:
 
 - Log in to <https://console.adobe.io/>
-- Switch to the correct organization in the top right corner
+- Switch to the correct organization in the top right corner. This must be the org where you AEM Cloud environment exists.
 - Switch to the Projects page
-- Find the AEM Cloud environment, once found click on the AEM Cloud environment
-  - You should see the overview page with the Products & Services: I/O Management API, Asset Compute, I/O Events, Experience Platform Launch API, and Asset Compute Journal
-  - If your AEM Cloud Environment does not have runtime enabled, [create a new project using the Firefly Template](https://experienceleague.adobe.com/docs/asset-compute/using/extend/setup-environment.html?lang=en#create-firefly-project) in the same org. Add the necessary services listed above to the workspace you would like to work in:  I/O Management API, Asset Compute, I/O Events, Experience Platform Launch API, and Asset Compute Journal
-- Add _Photoshop API - Creative Cloud Automation Services_:
-  - Click on _Add to Project_
-  - Select _API_
-  - Click on _Photoshop API - Creative Cloud Automation Services_
-  - Click on _Next_
-  - Select _Service Account (JWT)_
-  - Click on _Next_, which takes you to the Create a new Service Account (JWT) credential
-    - The public key is already provided
-  - Click on _Next_
-  - Select _Default Creative Cloud Automation Services configuration_
-  - Click on _Save configured API_
+- [Create a new project using the Firefly Template](https://experienceleague.adobe.com/docs/asset-compute/using/extend/setup-environment.html?lang=en#create-firefly-project). Move into the workspace you would like to work in.
+- Add the necessary services for Asset Compute Development:  I/O Management API, Asset Compute, I/O Events
+- Also add the following service necessary for creating this worker:
+  - Add _Photoshop API - Creative Cloud Automation Services_:
+    - Click on _Add to Project_
+    - Select _API_
+    - Click on _Photoshop API - Creative Cloud Automation Services_
+    - Click on _Next_
+    - Select _Service Account (JWT)_
+    - Click on _Next_, which takes you to the Create a new Service Account (JWT) credential
+      - The public key is already provided
+    - Click on _Next_
+    - Select _Default Creative Cloud Automation Services configuration_
+    - Click on _Save configured API_
 
 ## API
 ### Photoshop Action


### PR DESCRIPTION
if the AEM instance project in developer console does not have runtime enabled, the project will not have runtime and cannot deploy actions. There is not option to add runtime to the project in the console UI currently, so in this case, the developer will need to create a new firefly project in the same org as their aem instance and add all the necessary services

example aem instance w/o runtime:
<img width="1409" alt="Screen Shot 2021-01-04 at 4 23 28 PM" src="https://user-images.githubusercontent.com/20048485/103592921-30cb4700-4ea9-11eb-83b9-447ecec4613b.png">
