### PR TITLE
Change `photoshopAction` to `photoshopActions`

### DIFF
--- a/projects/worker-cc-photoshop/README.md
+++ b/projects/worker-cc-photoshop/README.md
@@ -37,7 +37,8 @@ These can be enabled in a AEM Cloud environment by following these steps:
 ## API
 ### Photoshop Action
 
-Uses the [Photoshop Actions API](https://github.com/adobe/aio-lib-photoshop-api#PhotoshopAPI+applyphotoshopActions)
+Uses the [Photoshop Actions API](https://github.com/adobe/aio-lib-photoshop-api#PhotoshopAPI+applyPhotoshopActions)
+
 REST API: https://adobedocs.github.io/photoshop-api-docs-pre-release/#api-Photoshop-photoshopActions
 
 Supported formats:

--- a/projects/worker-cc-photoshop/README.md
+++ b/projects/worker-cc-photoshop/README.md
@@ -37,7 +37,7 @@ These can be enabled in a AEM Cloud environment by following these steps:
 ## API
 ### Photoshop Action
 
-Uses the [Photoshop Actions API](https://github.com/adobe/aio-lib-photoshop-api#PhotoshopAPI+applyPhotoshopActions)
+Uses the [Photoshop Actions API](https://github.com/adobe/aio-lib-photoshop-api#PhotoshopAPI+applyphotoshopActions)
 REST API: https://adobedocs.github.io/photoshop-api-docs-pre-release/#api-Photoshop-photoshopActions
 
 Supported formats:
@@ -50,20 +50,20 @@ Supported formats:
     "worker": "<custom-worker-url>",
     "name": "rendition.jpg",
     "fmt": "jpg",
-    "photoshopAction": "<presigned-url>"
+    "photoshopActions": "<presigned-url>"
 }
 ```
 
 You can test using our sample [fisheye photoshop action](./files/fisheye.atn).
 
 #### Example Photoshop Action with multiple actions in the set
-If you have an action file with multiple photoshop actions in the set, use the `photoshopActionName` parameter to call only one of the actions.
+If you have an action file with multiple photoshop actions in the set, use the `photoshopActionsName` parameter to call only one of the actions.
 ```
 {
     "worker": "https:/mynamespace.adobeioruntime.net/api/v1/web/myactionname/worker-cc-photoshop",
     "name": "rendition.jpg",
-    "photoshopAction":"<presigned-url>",
-    "photoshopActionName": "Oil Paint Action 1"
+    "photoshopActions":"<presigned-url>",
+    "photoshopActionsName": "Oil Paint Action 1"
 }
 ```
 _Note: All actions in the set will be played if none are specified_
@@ -117,7 +117,7 @@ Review the [Asset Compute Extensibility Documentation](https://experienceleague.
 - For _Endpoint URL_, input the URL of the worker as seen after running `aio app deploy`: 
    - It should look like this: `https://<namespace>.adobeioruntime.net/api/v1/web/<appname>-0.0.1/<worker-name>`
    - _Note: If you see a different hostname: `adobeio-static.net`, your action got deployed with Web Assets. If this was not on purpose, please remove the Web Assets using `aio app delete web-assets`. Actions deployed with Web Assets use different authentification that is not supported out of the box by the Asset Compute Service. See details [here](https://www.adobe.io/apis/experienceplatform/project-firefly/docs.html#!AdobeDocs/project-firefly/master/getting_started/common_troubleshooting.md#action-authentication-errors)._
-- Add `photoshopAction` service parameter and set the value to presigned url for a photoshop action
+- Add `photoshopActions` service parameter and set the value to presigned url for a photoshop action
 - Click on Save
 
 ![Processing Profile](./files/processingProfile.png)

--- a/projects/worker-cc-photoshop/actions/worker-cc-photoshop/index.js
+++ b/projects/worker-cc-photoshop/actions/worker-cc-photoshop/index.js
@@ -53,8 +53,8 @@ function getAuthorization(params) {
  * @param {Object} instructions Rendition instructions
  * @returns {Object} options for Photoshop Actions Api request
  */
-async function setupPhotoshopActionsOptions(client, instructions, files) {
-    if (!instructions || !instructions.photoshopAction) {
+async function setuphotoshopActionsOptions(client, instructions, files) {
+    if (!instructions || !instructions.photoshopActions) {
         throw Error("Photoshop Action url not provided");
     }
 
@@ -62,27 +62,27 @@ async function setupPhotoshopActionsOptions(client, instructions, files) {
     // we must download the action file and add the `.atn`
     // extension to the file so Photoshop Service can
     // recognize it
-    let photoshopAction = instructions.photoshopAction;
+    let photoshopActions = instructions.photoshopActions;
     let ext;
     try {
-        ext = path.extname(photoshopAction).substring(1).toLowerCase();
+        ext = path.extname(photoshopActions).substring(1).toLowerCase();
     } catch (err) {
     }
     if (!ext) {
         const tempActionFilename = `${uuidv4()}_temp.atn`;
-        const aioLibActionFilename = `${uuidv4()}/photoshopaction.atn`;
-        await downloadFile(photoshopAction, tempActionFilename);
+        const aioLibActionFilename = `${uuidv4()}/photoshopActions.atn`;
+        await downloadFile(photoshopActions, tempActionFilename);
         await files.copy(tempActionFilename, aioLibActionFilename, { localSrc: true });
-        photoshopAction = aioLibActionFilename;
+        photoshopActions = aioLibActionFilename;
         
     }
     const options = {
         actions: [{
-            href: photoshopAction
+            href: photoshopActions
         }]
     }
-    if (options && Array.isArray(options.actions) && instructions.photoshopActionName) {
-        options.actions[0].actionName = instructions.photoshopActionName;
+    if (options && Array.isArray(options.actions) && instructions.photoshopActionsName) {
+        options.actions[0].actionName = instructions.photoshopActionsName;
     }
     return options;
 }
@@ -107,7 +107,7 @@ exports.main = worker(async (source, rendition, params) => {
     const tempFilename = `${uuidv4()}/rendition.${fmt}`;
 
     // call photoshopActions API
-    const options = await setupPhotoshopActionsOptions(client, rendition.instructions, files);
+    const options = await setuphotoshopActionsOptions(client, rendition.instructions, files);
     const result = await client.applyPhotoshopActions(source.url, tempFilename, options);
     console.log('Response from Photoshop API', result);
     if (result && result.outputs && result.outputs[0].status === 'failed') {

--- a/projects/worker-cc-photoshop/package-lock.json
+++ b/projects/worker-cc-photoshop/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "worker-cc-photoshop",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/projects/worker-cc-photoshop/test/asset-compute/worker-cc-photoshop/photoshopaction-jpg-png-actionName/params.json
+++ b/projects/worker-cc-photoshop/test/asset-compute/worker-cc-photoshop/photoshopaction-jpg-png-actionName/params.json
@@ -1,5 +1,5 @@
 {
     "fmt": "png",
-    "photoshopAction": "https://raw.githubusercontent.com/johnleetran/ps-actions-samples/master/actions/Oil-paint.atn",
-    "photoshopActionName": "Oil Paint 1"
+    "photoshopActions": "https://raw.githubusercontent.com/johnleetran/ps-actions-samples/master/actions/Oil-paint.atn",
+    "photoshopActionsName": "Oil Paint 1"
 }

--- a/projects/worker-cc-photoshop/test/asset-compute/worker-cc-photoshop/photoshopaction-jpg-png/params.json
+++ b/projects/worker-cc-photoshop/test/asset-compute/worker-cc-photoshop/photoshopaction-jpg-png/params.json
@@ -1,4 +1,4 @@
 {
     "fmt": "png",
-    "photoshopAction": "https://raw.githubusercontent.com/johnleetran/ps-actions-samples/master/actions/Oil-paint.atn" 
+    "photoshopActions": "https://raw.githubusercontent.com/johnleetran/ps-actions-samples/master/actions/Oil-paint.atn" 
 }


### PR DESCRIPTION
Fixes https://github.com/adobe/asset-compute-example-workers/issues/33

## Description

The correct term is "Photoshop Actions", even if there is only one action in the set. It was confusing to use the term `photoshop action`. 

Note: This code is just an example worker. It does not get released or used anywhere automatically. Therefore we do not need to keep it backwards compatible. In fact, it would be more confusing to keep code to make it backwards compatible since this is just sample code

## How Has This Been Tested?

Existing unit tests still pass. This is simply a name change.

## Screenshots (if appropriate):
<img width="1149" alt="Screen Shot 2021-02-02 at 8 36 05 AM" src="https://user-images.githubusercontent.com/20048485/106631512-b2a6a280-6531-11eb-8061-7ac0cc3e88f4.png">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change...however we don't release this library, so we don't have to keep backwards compatibility)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
